### PR TITLE
Made a change for correct usage in flutter pub get

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run the `packages get` command in your project directory:
 
 ```bash
   # install dependencies
-  flutter packages get
+  flutter pub get
 ```
 
 Once the build is complete, run the `run` command to start the app.


### PR DESCRIPTION
Although the command 'flutter package get' will work, but the correct usage to get the dependency's is flutter pub get. When ran 'flutter package -h' the usage shown is 'flutter pub <subcommand>. 

Please do consider