### PR TITLE
[Fixed] VideoDimensions

### DIFF
--- a/lib/src/pages/call.dart
+++ b/lib/src/pages/call.dart
@@ -59,7 +59,7 @@ class _CallPageState extends State<CallPage> {
     _addAgoraEventHandlers();
     await _engine.enableWebSdkInteroperability(true);
     VideoEncoderConfiguration configuration = VideoEncoderConfiguration();
-    configuration.dimensions = VideoDimensions(1920, 1080);
+    configuration.dimensions = VideoDimensions(width: 1920, height: 1080);
     await _engine.setVideoEncoderConfiguration(configuration);
     await _engine.joinChannel(Token, widget.channelName!, null, 0);
   }


### PR DESCRIPTION
```dart
VideoDimensions(1920, 1080); // Throws Error because it requires named parameters
VideoDimensions(width: 1920, height: 1080) ; // Fixed by using named parameters
```
on `line 62` in `call.dart`